### PR TITLE
Adding repclient for loadtest, fixed DB query

### DIFF
--- a/src/bin/repclient.rs
+++ b/src/bin/repclient.rs
@@ -1,0 +1,77 @@
+extern crate futures;
+extern crate http;
+extern crate bytes;
+extern crate env_logger;
+extern crate log;
+extern crate prost;
+#[macro_use]
+extern crate prost_derive;
+extern crate tokio_core;
+extern crate tower_h2;
+extern crate tower_http;
+extern crate tower_grpc;
+
+use futures::Future;
+use futures::future::join_all;
+use tokio_core::reactor::Core;
+use tokio_core::net::TcpStream;
+use tower_grpc::Request;
+use tower_h2::client::Connection;
+use std::env;
+
+pub mod services {
+    include!(concat!(env!("OUT_DIR"), "/services.rs"));
+}
+
+pub mod domain {
+    include!(concat!(env!("OUT_DIR"), "/domain.rs"));
+}
+
+pub mod base {
+    include!(concat!(env!("OUT_DIR"), "/base.rs"));
+}
+
+use services::client::SimpleService;
+use domain::ItemSpecifier;
+
+pub fn main() {
+  let _ = ::env_logger::init();
+  let mut core = Core::new().unwrap();
+  let reactor = core.handle();
+
+  // get cmd line arguments
+  let args: Vec<String> = env::args().collect();
+  let ident = &args[1];
+  let rep = &args[2].parse::<u32>().unwrap();
+
+  let addr = "[::1]:50051".parse().unwrap();
+  let uri: http::Uri = format!("http://localhost:50055").parse().unwrap();
+
+  let get_item_data = TcpStream::connect(&addr, &reactor)
+    .and_then(move |socket| {
+      Connection::handshake(socket, reactor).map_err(|_| panic!("failed HTTP/2.0 handshake"))
+    })
+    .map(|conn| {
+      use tower_http::add_origin;
+
+      let conn = add_origin::Builder::new().uri(uri).build(conn).unwrap();
+      SimpleService::new(conn)
+    });
+
+    // get the simple service
+    let mut stub = core.run(get_item_data).unwrap() ;
+    let v = (0..*rep).collect::<Vec<u32>>();
+    let vf = v.iter().map(move |x|
+       stub.get_item_data(Request::new(ItemSpecifier { ident: ident.clone().to_string() } )).map_err(|e| panic!("grpc request failed; err={:?}", e))
+     .and_then(|_| {
+      print!(".");
+      Ok(())
+    })
+    .map_err(|e| {
+      println!("err = {:?}", e);
+    })
+    );
+    let num = vf.map(|f| core.run(f)).fold(0u32, |acc, _| acc+1);
+    println!("found {} items", num);
+}
+

--- a/src/bin/service.rs
+++ b/src/bin/service.rs
@@ -95,7 +95,7 @@ WHERE ident=:ident"#;
                                ident: from_value(row.take(1).unwrap()),
                                name: from_value(row.take(2).unwrap()),
                                created_at: mysql_value_to_timestamp(row.take(3)),
-                               description: from_value(row.take(6).unwrap()),
+                               description: from_value(row.take(4).unwrap()),
                            })
                        })).map_err(|e| { eprintln!("Error executing the query: {}", e); make_grpc_error(tower_grpc::Status::INTERNAL) } );
 
@@ -143,9 +143,11 @@ impl server::SimpleService for ItemServer {
 
         let cache = CACHE.lock().unwrap();
         if cache.contains_key(&ident.clone()) {
+          print!("c");
           let cached = cache.get(&ident.to_string().clone());
           Box::new(futures::future::ok(Response::new(cached.unwrap().clone())))
         } else {
+          print!("q");
           let future = self.retrieve_item_data(ident.clone());
           Box::new(future)
         }

--- a/src/bin/service.rs
+++ b/src/bin/service.rs
@@ -143,11 +143,9 @@ impl server::SimpleService for ItemServer {
 
         let cache = CACHE.lock().unwrap();
         if cache.contains_key(&ident.clone()) {
-          print!("c");
           let cached = cache.get(&ident.to_string().clone());
           Box::new(futures::future::ok(Response::new(cached.unwrap().clone())))
         } else {
-          print!("q");
           let future = self.retrieve_item_data(ident.clone());
           Box::new(future)
         }


### PR DESCRIPTION
repclient takes ident + count as arguments and uses a single
SimpleServiceServer to hit the backend multiple times.